### PR TITLE
fix duplicated grafana color mapping on dashboard for spine1:ethernet-1/31

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ docker exec -it client1 bash
 
 The DC fabric used in this lab consists of three leaves, two spines and two DC gateways interconnected with each other as shown in the diagram.
 
-![pic1](https://user-images.githubusercontent.com/86619221/205601635-609eb772-833b-4ac9-b2ab-dc3ed661c4a1.JPG)
+![pic1](https://gitlab.com/rdodin/pics/-/wikis/uploads/2abc386a775e74aa877c8fb0668b58ae/image.png)
 
 Leaves and spines use Nokia SR Linux IXR-D2 and IXR-D3L chassis respectively, DC gateways uses SR-1 chassis. Each network element of this topology is equipped with a [Fabric startup configuration file](configs/fabric) and [DCI startup configuration file](configs/dci) that is applied at the node's startup.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ SR Linux has first-class Streaming Telemetry support thanks to 100% YANG coverag
 
 The Nokia Service Router Operating System (SR OS) is robust and scalable OS and provides the foundation of Nokia's comprehensive portfolio of physical and virtualized routers. Provides Streaming Telemetry based on the OpenConfig gnmi.proto and the proprietary NOKIA SR OS YANG data models suporting sample, target-defined, on-change telemetry based on dial-in or dial-out calls.
 
-This lab is a small augmentation of the original srl-telemetry-lab <https://github.com/srl-labs/srl-telemetry-lab> wich basically represents a small Clos fabric with [Nokia SR Linux](https://learn.srlinux.dev/) switches running as containers and a DC gateways layer composed by [Nokia SROS](https://www.nokia.com/networks/technologies/service-router-operating-system/) DC Gateways on a containerized vSIM image connected through an ovs-bridge. The lab topology consists of a Clos/DCI, plus a Streaming Telemetry stack comprised of gnmic, prometheus and grafana applications.
+This lab is a small augmentation of the original srl-telemetry-lab <https://github.com/srl-labs/srl-telemetry-lab> wich basically represents a small Clos fabric with [Nokia SR Linux](https://learn.srlinux.dev/) switches running as containers and a DC gateways layer composed by [Nokia SROS](https://www.nokia.com/networks/technologies/service-router-operating-system/) DC Gateways on a containerized vSIM image connected through a "tc mirred function" that is very well described in the @hellt forum (https://netdevops.me/2021/transparently-redirecting-packetsframes-between-interfaces/). The lab topology consists of a Clos/DCI, plus a Streaming Telemetry stack comprised of gnmic, prometheus and grafana applications.
 
 Goals of this lab:
 
@@ -49,9 +49,9 @@ docker exec -it client1 bash
 
 The DC fabric used in this lab consists of three leaves, two spines and two DC gateways interconnected with each other as shown in the diagram.
 
-![pic1](https://gitlab.com/rdodin/pics/-/wikis/uploads/2abc386a775e74aa877c8fb0668b58ae/image.png)
+![pic1](https://user-images.githubusercontent.com/86619221/205601635-609eb772-833b-4ac9-b2ab-dc3ed661c4a1.JPG)
 
-Leaves and spines use Nokia SR Linux IXR-D2 and IXR-D3L chassis respectively, DC gateways uses SR-1 chassis. Each network element of this topology is equipped with a [startup configuration file](configs/fabric/) that is applied at the node's startup.
+Leaves and spines use Nokia SR Linux IXR-D2 and IXR-D3L chassis respectively, DC gateways uses SR-1 chassis. Each network element of this topology is equipped with a [Fabric startup configuration file](configs/fabric) and [DCI startup configuration file](configs/dci) that is applied at the node's startup.
 
 Once booted, network nodes will come up with interfaces, underlay protocols and overlay service configured. The fabric is configured with Layer 2 EVPN service between the leaves and DC gateways.
 
@@ -140,11 +140,11 @@ Grafana is a key component of this lab. Lab's topology file includes grafana nod
 
 Grafana dashboard provided by this repository provides multiple views on the collected real-time data. Powered by [flowchart plugin](https://grafana.com/grafana/plugins/agenty-flowcharting-panel/) it overlays telemetry sourced data over graphics such as topology and front panel views:
 
-![pic3](https://gitlab.com/rdodin/pics/-/wikis/uploads/42b0781e4bd0cbea5321c94c6e9ae808/image.png)
+![pic3](https://user-images.githubusercontent.com/86619221/205601697-bd5b68f0-e2c6-49d3-a1f3-1cb5b67b34d9.JPG)
 
 Using the flowchart plugin and real telemetry data users can create interactive topology maps (aka weathermap) with a visual indication of link rate/utilization.
 
-![pic2](https://gitlab.com/rdodin/pics/-/wikis/uploads/10efae56f6af5475bb37a143f78f0300/image.png)
+![pic2](https://user-images.githubusercontent.com/86619221/205601728-f3b254d1-2b03-4e75-b0e4-eb89cf54789a.JPG)
 
 ## Access details
 

--- a/configs/grafana/dashboards/telemetry-dashboard.json
+++ b/configs/grafana/dashboards/telemetry-dashboard.json
@@ -24,7 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 2,
-  "iteration": 1667912823272,
+  "iteration": 1669746117466,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -7082,111 +7082,6 @@
               },
               {
                 "aggregation": "current",
-                "alias": "oper-state_spine-1_e1/32",
-                "column": "Time",
-                "dateColumn": "Time",
-                "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                "dateTHData": [
-                  {
-                    "color": "rgba(245, 54, 54, 0.9)",
-                    "comparator": "ge",
-                    "level": 0,
-                    "value": "0d"
-                  },
-                  {
-                    "color": "rgba(237, 129, 40, 0.89)",
-                    "comparator": "ge",
-                    "level": 0,
-                    "value": "-1d"
-                  },
-                  {
-                    "color": "rgba(50, 172, 45, 0.97)",
-                    "comparator": "ge",
-                    "level": 0,
-                    "value": "-1w"
-                  }
-                ],
-                "decimals": 0,
-                "eventData": [],
-                "eventProp": "id",
-                "eventRegEx": false,
-                "gradient": false,
-                "hidden": false,
-                "invert": true,
-                "linkData": [],
-                "linkProp": "id",
-                "linkRegEx": true,
-                "mappingType": 1,
-                "metricType": "serie",
-                "newRule": false,
-                "numberTHData": [
-                  {
-                    "color": "#C4162A",
-                    "comparator": "ge",
-                    "level": 0
-                  },
-                  {
-                    "color": "#37872D",
-                    "comparator": "ge",
-                    "level": 0,
-                    "value": 1
-                  }
-                ],
-                "order": 59,
-                "overlayIcon": false,
-                "pattern": "oper-state:spine1:57400:ethernet-1/32",
-                "rangeData": [],
-                "reduce": true,
-                "refId": "A",
-                "sanitize": false,
-                "shapeData": [
-                  {
-                    "colorOn": "a",
-                    "hidden": false,
-                    "pattern": "4",
-                    "style": "fillColor"
-                  }
-                ],
-                "shapeProp": "id",
-                "shapeRegEx": true,
-                "stringTHData": [
-                  {
-                    "color": "rgba(50, 172, 45, 0.97)",
-                    "comparator": "eq",
-                    "level": 0,
-                    "value": "/.*/"
-                  },
-                  {
-                    "color": "rgba(237, 129, 40, 0.89)",
-                    "comparator": "eq",
-                    "level": 0,
-                    "value": "/.*warning.*/"
-                  },
-                  {
-                    "color": "rgba(245, 54, 54, 0.9)",
-                    "comparator": "eq",
-                    "level": 0,
-                    "value": "/.*(success|ok).*/"
-                  }
-                ],
-                "textData": [],
-                "textProp": "id",
-                "textRegEx": true,
-                "tooltip": true,
-                "tooltipColors": false,
-                "tooltipLabel": "",
-                "tooltipOn": "a",
-                "tpDirection": "v",
-                "tpGraph": false,
-                "tpGraphScale": "linear",
-                "tpGraphSize": "100%",
-                "tpGraphType": "line",
-                "type": "number",
-                "unit": "short",
-                "valueData": []
-              },
-              {
-                "aggregation": "current",
                 "alias": "oper-state_spine-2_e1/32",
                 "column": "Time",
                 "dateColumn": "Time",
@@ -7237,7 +7132,7 @@
                     "value": 1
                   }
                 ],
-                "order": 60,
+                "order": 59,
                 "overlayIcon": false,
                 "pattern": "oper-state:spine2:57400:ethernet-1/32",
                 "rangeData": [],
@@ -7342,7 +7237,7 @@
                     "value": 1
                   }
                 ],
-                "order": 61,
+                "order": 60,
                 "overlayIcon": false,
                 "pattern": "dcgw2:57400:1/1/c1/1",
                 "rangeData": [],
@@ -7447,7 +7342,7 @@
                     "value": 1
                   }
                 ],
-                "order": 62,
+                "order": 61,
                 "overlayIcon": false,
                 "pattern": "dcgw2:57400:1/1/c3/1",
                 "rangeData": [],
@@ -7552,7 +7447,7 @@
                     "value": 1
                   }
                 ],
-                "order": 63,
+                "order": 62,
                 "overlayIcon": false,
                 "pattern": "dcgw1:57400:1/1/c3/1",
                 "rangeData": [],
@@ -7657,7 +7552,7 @@
                     "value": 1
                   }
                 ],
-                "order": 64,
+                "order": 63,
                 "overlayIcon": false,
                 "pattern": "dcgw1:57400:1/1/c2/1",
                 "rangeData": [],
@@ -7762,7 +7657,7 @@
                     "value": 1
                   }
                 ],
-                "order": 65,
+                "order": 64,
                 "overlayIcon": false,
                 "pattern": "dcgw1:57400:1/1/c1/1",
                 "rangeData": [],
@@ -7867,7 +7762,7 @@
                     "value": 1
                   }
                 ],
-                "order": 66,
+                "order": 65,
                 "overlayIcon": false,
                 "pattern": "dcgw2:57400:1/1/c1/1",
                 "rangeData": [],
@@ -12889,7 +12784,7 @@
       "type": "row"
     }
   ],
-  "refresh": "5s",
+  "refresh": "",
   "schemaVersion": 36,
   "style": "dark",
   "tags": [],


### PR DESCRIPTION
Following task has been done in this PR:

- Delete a duplicated color map applied on dashboard for spine1:ethernet-1/31
- Update README.md images (last two only)
- Update README.md with a link to fabric and dci config files for network elements respectively instead of fabric only. 
- Update README.md stating "tc mirred function" for VSROS connectivity instead of ovs-switch.